### PR TITLE
Add main classes for bot sender and PDF generator

### DIFF
--- a/modules/bot-sender/src/main/java/com/marketflow/bot/SenderApp.java
+++ b/modules/bot-sender/src/main/java/com/marketflow/bot/SenderApp.java
@@ -1,0 +1,15 @@
+package com.marketflow.bot;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Простейшее приложение-отправитель.
+ */
+public class SenderApp {
+    private static final Logger log = LoggerFactory.getLogger(SenderApp.class);
+
+    public static void main(String[] args) {
+        log.info("Bot Sender started");
+    }
+}

--- a/modules/pdf-generator/src/main/java/com/marketflow/pdf/GeneratorApp.java
+++ b/modules/pdf-generator/src/main/java/com/marketflow/pdf/GeneratorApp.java
@@ -1,0 +1,15 @@
+package com.marketflow.pdf;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Простейшее приложение-генератор PDF.
+ */
+public class GeneratorApp {
+    private static final Logger log = LoggerFactory.getLogger(GeneratorApp.class);
+
+    public static void main(String[] args) {
+        log.info("PDF Generator started");
+    }
+}


### PR DESCRIPTION
## Summary
- add directories for bot-sender and pdf-generator modules
- implement simple `SenderApp` and `GeneratorApp` with logging main methods

## Testing
- `mvn package` in `modules/bot-sender` *(fails: Could not download dependencies)*
- `mvn package` in `modules/pdf-generator` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68612424fa1083308ec753e25dbbe0b7