### PR TITLE
Fix EngineApp getSourcesFromArgs

### DIFF
--- a/modules/strategy-engine/src/main/java/com/marketflow/strategy/EngineApp.java
+++ b/modules/strategy-engine/src/main/java/com/marketflow/strategy/EngineApp.java
@@ -7,6 +7,7 @@ import com.marketflow.strategy.service.StrategyGenerationService;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -81,6 +82,6 @@ public class EngineApp {
                 return Arrays.asList(args);
             }
         }
-        return Arrays.asList();
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
## Summary
- fix return type for `getSourcesFromArgs` in `EngineApp`

## Testing
- `mvn -q test` *(fails: could not download org.springframework.boot:spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688b529e81c48330955f7606a0bd2ca0